### PR TITLE
Fix production values in decimals causing 0 production error

### DIFF
--- a/prototypes/string-util.lua
+++ b/prototypes/string-util.lua
@@ -14,7 +14,7 @@ end
 ---@param coefficient number
 local function multiplyStringValue(text, coefficient)
   if not text then return nil end
-  local n = string.match(text, "%d+")
+  local n, _ = string.gsub(text, "%a", "")
   local s = string.match(text, "%a+")
   return tostring(tonumber(n) * coefficient) .. s
 end


### PR DESCRIPTION
The regex matching causes problems when a solar panel generates e.g. `0.6MW`. This is most easily seen with this mod: https://mods.factorio.com/mod/Advanced-Electric-Revamped-v16

Instead of trying to match numbers, strip the alphabetic characters.

This is what caused the error mentioned here: https://mods.factorio.com/mod/solar-productivity/discussion/648942c2cfab341dd44ca548

As a warning, I'm not very knowledgeable about lua in general or the Factorio modding APIs.