### PR TITLE
Fix Accumulator circuit connection & save stored power

### DIFF
--- a/scripts/upgrader.lua
+++ b/scripts/upgrader.lua
@@ -97,6 +97,8 @@ local function update_prototype(old)
     output_signal = control_behavior.output_signal
   end
 
+  local energy = old.energy
+
   old.destroy()
 
   local new = surface.create_entity({
@@ -121,6 +123,8 @@ local function update_prototype(old)
     end
     control_behavior.output_signal = output_signal
   end
+  
+  new.energy = energy
 
   if new and new.valid and damage > 0 then
     new.damage(damage, game.forces.neutral)

--- a/scripts/upgrader.lua
+++ b/scripts/upgrader.lua
@@ -82,6 +82,14 @@ local function update_prototype(old)
   local position  = old.position
   local player    = old.last_user
   local damage    = old.prototype.max_health - old.health
+  
+  local connections = nil;
+  if old.circuit_connected_entities ~= nil then
+    connections = {}
+    for ___, connection in pairs(old.circuit_connection_definitions) do
+      table.insert(connections, connection)
+    end
+  end
 
   old.destroy()
 
@@ -93,6 +101,12 @@ local function update_prototype(old)
     create_build_effect_smoke = false,
     raise_built = true,
   })
+  
+  if connections ~= nil then
+    for ___, connection in pairs(connections) do
+      local connected = new.connect_neighbour(connection);
+    end
+  end
 
   if new and new.valid and damage > 0 then
     new.damage(damage, game.forces.neutral)

--- a/scripts/upgrader.lua
+++ b/scripts/upgrader.lua
@@ -90,6 +90,12 @@ local function update_prototype(old)
       table.insert(connections, connection)
     end
   end
+  
+  local output_signal = nil
+  local control_behavior = old.get_control_behavior()
+  if control_behavior ~= nil then
+    output_signal = control_behavior.output_signal
+  end
 
   old.destroy()
 
@@ -106,6 +112,14 @@ local function update_prototype(old)
     for ___, connection in pairs(connections) do
       local connected = new.connect_neighbour(connection);
     end
+  end
+  
+  control_behavior = new.get_control_behavior()
+  if control_behavior ~= nil then
+    if output_signal == nil then
+      output_signal = { type="virtual", name="" }
+    end
+    control_behavior.output_signal = output_signal
   end
 
   if new and new.valid and damage > 0 then


### PR DESCRIPTION
1. 9cf53e4379ed21e819f726e9c3853f8563bd220b
Copies all circuit connections from the old accumulator entity onto the new one.

2. 11ef382c7fef08122f8d39d355aa9c681a4dd16c
Copies the output signal of the accumulator from the old entity to the new one, with a safe-guard in case no signal is set.

3. 03976b71186b7db4f82b0ca2a0bf346f0d30bae8
Copies stored energy from the old accumulator entity to the new one, so you don't lose all the stored power when the research is completed.