### PR TITLE
Update entities built on a space platform

### DIFF
--- a/scripts/upgrader.lua
+++ b/scripts/upgrader.lua
@@ -282,6 +282,7 @@ local function set_filters()
   script.set_event_filter(defines.events.on_robot_built_entity --[[@as uint]] , upgrader_filter)
   script.set_event_filter(defines.events.script_raised_built --[[@as uint]] , upgrader_filter)
   script.set_event_filter(defines.events.script_raised_revive --[[@as uint]] , upgrader_filter)
+  script.set_event_filter(defines.events.on_space_platform_built_entity --[[@as uint]] , upgrader_filter)
 end
 
 -- ============================================================================
@@ -319,6 +320,7 @@ Upgrader.events = {
   [defines.events.on_robot_built_entity] = on_built,
   [defines.events.script_raised_built]   = on_built,
   [defines.events.script_raised_revive]  = on_built,
+  [defines.events.on_space_platform_built_entity] = on_built,
   [defines.events.on_runtime_mod_setting_changed] = update_settings,
 }
 


### PR DESCRIPTION
When you built solar panels and accumulators on a space platform they weren't getting the increased energy values because. I poked at it and it was because `on_space_platform_built_entity` needs to be listened for.