### PR TITLE
Added Muluna's satellite radar to list of excluded entities.

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -12,6 +12,7 @@ _G.SP_BLACKLIST = {
   ['warp-power-2'] = true, -- warptorio-space-age
   ['warp-power-3'] = true, -- warptorio-space-age
   ['se-spaceship-console'] = true, -- Space Exploration
+  ['muluna-satellite-radar'] = true,
 }
 
 require '__solar-productivity__.prototypes.technology'


### PR DESCRIPTION
This PR adds Muluna's "Satellite Radar," an accumulator prototype governed by scripts that interfere in solar-productivity, to the list of excluded entities.