### PR TITLE
Fix /sp-transition command

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.1.13
+Date: 2026-02-06
+  Bugfixes:
+    - Fixed /sp-transition command: downgraded entities were immediately re-upgraded because raise_built triggered on_built, queueing them back for upgrade.
+---------------------------------------------------------------------------------------------------
 Version: 2.1.12
 Date: 2025-09-27
   Changes:

--- a/scripts/upgrader.lua
+++ b/scripts/upgrader.lua
@@ -201,6 +201,7 @@ end
 --- upgrade the entity to higher tier if possible
 ---@param event EventData.on_built_entity
 local function on_built(event)
+  if storage.transitioning then return end
   local entity = event.created_entity or event.entity or event.destination
   if not entity or not entity.valid then
     return
@@ -303,6 +304,10 @@ local function on_tick()
     downgrade_prototype(pop(to_downgrade))
     d_size = d_size - 1
   end
+
+  if storage.transitioning and size(to_downgrade) == 0 then
+    storage.transitioning = false
+  end
 end
 
 -- ============================================================================
@@ -357,6 +362,8 @@ Upgrader.add_commands = function()
   -- Usage: type "/sp-transition" in game console
   -- Removes all upgraded and places back the  base prototype
   commands.add_command('sp-transition', { 'command-help.sp-transition' }, function()
+    storage.transitioning = true
+    storage.to_update = Queue.new()  -- Clear pending upgrades
     replace_all_upgrades()
   end)
 end


### PR DESCRIPTION
## Fix /sp-transition command: entities immediately re-upgraded after downgrade

### Problem

The `/sp-transition` command doesn't work — entities are downgraded for a brief moment, then immediately upgraded back.

**Root cause:** `downgrade_prototype()` creates the base entity with `raise_built = true`, which triggers the `on_built` handler. This pushes the newly created base entity into the `to_update` queue, causing `on_tick` to upgrade it right back.

### Fix

Added a `storage.transitioning` flag that prevents `on_built` from queueing entities during transition:

1. `/sp-transition` sets `storage.transitioning = true` and clears the `to_update` queue
2. `on_built` skips queueing when the flag is active
3. The flag is cleared in `on_tick` once the `to_downgrade` queue is empty

### Changes

- `scripts/upgrader.lua` — 3 small changes.
