### PR TITLE
Removing redundant code

### DIFF
--- a/info.json
+++ b/info.json
@@ -21,7 +21,7 @@
     "(?) FactorioExtended-Plus-Power",
     "(?) Krastorio2",
     "(?) Lindors-Advanced-Solar",
-    "(?) SaveMyPower",
+    "(?) SaveMyPower >= 0.2.0",
     "(?) skan-advanced-solar",
     "(?) space-exploration",
     "(?) Speckled-advanced-solar",
@@ -29,7 +29,7 @@
     "(?) Advanced-Electric-Revamped-GOR-v16",
     "(?) Lindors-GOR-Advanced-Solar",
     "(?) IndustrialRevolution3",
-    "(?) Cerys >= 0.9.5"
+    "(?) Cerys-Moon-of-Fulgora >= 0.9.5"
   ],
   "description": "Increase the efficiency of Solar panels and Accumulators by progressing through technology!",
   "factorio_version": "2.0"

--- a/prototypes/entity.lua
+++ b/prototypes/entity.lua
@@ -3,99 +3,80 @@ local sutil = require '__solar-productivity__.prototypes.string-util'
 
 -- ============================================================================
 
+---@param base table
+---@param bes table
+local function make_variations(base, bes)
+    local result = base.name
+    if base.minable and base.minable.result then
+        result = base.minable.result
+    end
+    if not data.raw.item[result] and not data.raw['item-with-tags'][result] then
+        return false -- 'item-with-tags' in case if some mod like SaveMyPower modifies it to item-with-tags
+    end
+    local bonus = 1
+    local max_bonus = #SP.BONUS
+    for level = 1, SP.LEVELS do
+        bonus = bonus + SP.BONUS[math.min(level, max_bonus)]
+        local prototype = table.deepcopy(base)
+        prototype.name               = SP.ENTITY .. tostring(level) .. '-' .. base.name
+        prototype.localised_name     = prototype.localised_name or {'entity-name.' .. base.name}
+        prototype.placeable_by       = {item = result, count = 1}
+        if bes ~= nil then
+            prototype.energy_source = {
+                type                 = bes.type,
+                buffer_capacity      = sutil.msv(bes.buffer_capacity, bonus),
+                usage_priority       = bes.usage_priority,
+                input_flow_limit     = sutil.msv(bes.input_flow_limit, bonus),
+                output_flow_limit    = sutil.msv(bes.output_flow_limit, bonus),
+                render_no_power_icon = bes.render_no_power_icon,
+            }
+        else
+            prototype.production     = sutil.msv(base.production, bonus)
+        end
+        prototype.hidden_in_factoriopedia = true
+        if base.next_upgrade then
+            prototype.next_upgrade   = SP.ENTITY .. tostring(level) .. '-' .. base.next_upgrade
+        end
+        data:extend({prototype})
+    end
+    return true
+end
+
+-- ============================================================================
+
 ---@param prototype_name string
 local function make_solar_panel_variations(prototype_name)
-  if not prototype_name
-    or not data.raw['solar-panel'][prototype_name]
-    or not data.raw['solar-panel'][prototype_name].production
-    or (SP_BLACKLIST and SP_BLACKLIST[prototype_name])
-  then
-    log('SP: invalid SolarPanelPrototype')
-    return
-  end
-
-  local base = data.raw['solar-panel'][prototype_name]
-  local bonus = 1
-  local max_bonus = #SP.BONUS
-  local result = base.name
-  if base.minable and base.minable.result then
-    result = base.minable.result
-  end
-  if not data.raw.item[result] then
-    return
-  end
-
-  for level = 1, SP.LEVELS do
-    bonus = bonus + SP.BONUS[math.min(level, max_bonus)]
-    local prototype = table.deepcopy(base)
-
-    prototype.name            = SP.ENTITY..tostring(level)..'-'..base.name
-    prototype.localised_name  = prototype.localised_name or {'entity-name.'..base.name}
-    prototype.placeable_by    = { item = result, count = 1 }
-    prototype.production      = sutil.msv(base.production, bonus)
-    prototype.hidden_in_factoriopedia = true
-    if base.next_upgrade then
-      prototype.next_upgrade = SP.ENTITY..tostring(level)..'-'..base.next_upgrade
+    if not prototype_name
+        or not data.raw['solar-panel'][prototype_name]
+        or not data.raw['solar-panel'][prototype_name].production
+        or (SP_BLACKLIST and SP_BLACKLIST[prototype_name])
+    then
+        log('SP: invalid SolarPanelPrototype')
+        return false
     end
-
-    data:extend({prototype})
-  end
-  return true
+    local base = data.raw['solar-panel'][prototype_name]
+    return make_variations(base, nil)
 end
 
 -- ============================================================================
 
 ---@param prototype_name string
 local function make_accumulator_variations(prototype_name)
-  if not prototype_name 
-    or not data.raw['accumulator'][prototype_name]
-    or not data.raw['accumulator'][prototype_name].energy_source
-    or (SP_BLACKLIST and SP_BLACKLIST[prototype_name])
-  then
-    log('SP: invalid AccumulatorPrototype')
-    return
-  end
-
-  local base = table.deepcopy(data.raw['accumulator'][prototype_name])
-  local bes = base.energy_source
-  local bonus = 1
-  local max_bonus = #SP.BONUS
-  local result = base.name
-  if base.minable and base.minable.result then
-    result = base.minable.result
-  end
-  if not data.raw.item[result] then
-    return
-  end
-
-  for level = 1, SP.LEVELS do
-    bonus = bonus + SP.BONUS[math.min(level, max_bonus)]
-    local prototype = table.deepcopy(base)
-
-    prototype.name            = SP.ENTITY..tostring(level)..'-'..base.name
-    prototype.localised_name  = prototype.localised_name or {'entity-name.'..base.name}
-    prototype.placeable_by    = { item = result, count = 1 }
-    prototype.energy_source   = {
-      type                    = bes.type,
-      buffer_capacity         = sutil.msv(bes.buffer_capacity, bonus),
-      usage_priority          = bes.usage_priority,
-      input_flow_limit        = sutil.msv(bes.input_flow_limit, bonus),
-      output_flow_limit       = sutil.msv(bes.output_flow_limit, bonus),
-      render_no_power_icon    = bes.render_no_power_icon
-    }
-    prototype.hidden_in_factoriopedia = true
-    if base.next_upgrade then
-      prototype.next_upgrade = SP.ENTITY..tostring(level)..'-'..base.next_upgrade
+    if not prototype_name
+        or not data.raw['accumulator'][prototype_name]
+        or not data.raw['accumulator'][prototype_name].energy_source
+        or (SP_BLACKLIST and SP_BLACKLIST[prototype_name])
+    then
+        log('SP: invalid AccumulatorPrototype')
+        return false
     end
-
-    data:extend({prototype})
-  end
-  return true
+    local base = table.deepcopy(data.raw['accumulator'][prototype_name])
+    return make_variations(base, base.energy_source)
 end
 
 -- ============================================================================
 
 return {
-  make_solar_panel_variations = make_solar_panel_variations,
-  make_accumulator_variations = make_accumulator_variations,
+    make_solar_panel_variations = make_solar_panel_variations,
+    make_accumulator_variations = make_accumulator_variations,
 }

--- a/prototypes/shared.lua
+++ b/prototypes/shared.lua
@@ -17,6 +17,17 @@ SOL_PROD.ENTITY = 'sp-'
 
 SOL_PROD.TECHNOLOGY = 'solar-productivity-'
 
+SOL_PROD.TECHNOLOGY_ICON = '__base__/graphics/technology/solar-energy.png'
+
 SOL_PROD.COMPATIBILITY_LIST = require 'prototypes.compatibility'
+
+SOL_PROD.PACKS = {
+  automation = {'automation-science-pack', 1},
+  logistic   = {'logistic-science-pack',   1},
+  chemical   = {'chemical-science-pack',   1},
+  production = {'production-science-pack', 1},
+  utility    = {'utility-science-pack',    1},
+  space      = {'space-science-pack',      1},
+}
 
 return SOL_PROD

--- a/prototypes/technology.lua
+++ b/prototypes/technology.lua
@@ -1,121 +1,77 @@
 local SP = require '__solar-productivity__.prototypes.shared'
 local str = tostring
 
+local function create_sp_technology(level, overrides)
+  local base = {
+    type  = 'technology',
+    name  = SP.TECHNOLOGY .. level,
+    icons = util.technology_icon_constant_productivity(SP.TECHNOLOGY_ICON),
+    localised_description = {'technology-description.solar-productivity', str(SP.BONUS[level] * 100)},
+    effects = {
+      {
+        type = 'nothing',
+        effect_description = {'effect-description.solar-productivity', str(SP.BONUS[level] * 100)},
+      },
+    },
+    upgrade = true,
+    order = 'sp-' .. level,
+  }
+
+  for k, v in pairs(overrides) do
+    base[k] = v
+  end
+
+  return base
+end
+
 data:extend({
   -- SP-1
-  {
-    type = 'technology',
-    name = SP.TECHNOLOGY..'1',
-    icons = util.technology_icon_constant_productivity('__base__/graphics/technology/solar-energy.png'),
-    localised_description = {'technology-description.solar-productivity', str(SP.BONUS[1] * 100)},
-    effects =
+  create_sp_technology(
+    1,
     {
-      {
-        type = 'nothing',
-        effect_description = {'effect-description.solar-productivity', str(SP.BONUS[1] * 100)}
-      },
-    },
-    prerequisites = {'solar-energy', 'electric-energy-accumulators'},
-    unit =
-    {
-      count = 250,
-      ingredients =
-      {
-        {'automation-science-pack', 1},
-        {'logistic-science-pack', 1}
-      },
-      time = 60
-    },
-    upgrade = true,
-    order = 'sp-1'
-  },
+      prerequisites = {'solar-energy', 'electric-energy-accumulators'},
+      unit = {
+        count = 250,
+        ingredients = {SP.PACKS.automation, SP.PACKS.logistic},
+        time = 60,
+      }
+    }
+  ),
   -- SP-2
-  {
-    type = 'technology',
-    name = SP.TECHNOLOGY..'2',
-    icons = util.technology_icon_constant_productivity('__base__/graphics/technology/solar-energy.png'),
-    localised_description = {'technology-description.solar-productivity', str(SP.BONUS[2] * 100)},
-    effects =
+  create_sp_technology(
+    2,
     {
-      {
-        type = 'nothing',
-        effect_description = {'effect-description.solar-productivity', str(SP.BONUS[2] * 100)}
-      },
-    },
-    prerequisites = {SP.TECHNOLOGY..'1', 'chemical-science-pack'},
-    unit =
-    {
-      count = 500,
-      ingredients =
-      {
-        {'automation-science-pack', 1},
-        {'logistic-science-pack', 1},
-        {'chemical-science-pack', 1}
-      },
-      time = 60
-    },
-    upgrade = true,
-    order = 'sp-2'
-  },
+      prerequisites = {SP.TECHNOLOGY..'1', 'chemical-science-pack'},
+      unit = {
+        count = 500,
+        ingredients = {SP.PACKS.automation, SP.PACKS.logistic, SP.PACKS.chemical},
+        time = 60,
+      }
+    }
+  ),
   -- SP-3
-  {
-    type = 'technology',
-    name = SP.TECHNOLOGY..'3',
-    icons = util.technology_icon_constant_productivity('__base__/graphics/technology/solar-energy.png'),
-    localised_description = {'technology-description.solar-productivity', str(SP.BONUS[3] * 100)},
-    effects =
+  create_sp_technology(
+    3,
     {
-      {
-        type = 'nothing',
-        effect_description = {'effect-description.solar-productivity', str(SP.BONUS[3] * 100)}
-      },
-    },
-    prerequisites = {SP.TECHNOLOGY..'2', 'production-science-pack','utility-science-pack'},
-    unit =
-    {
-      count = 1000,
-      ingredients =
-      {
-        {'automation-science-pack', 1},
-        {'logistic-science-pack', 1},
-        {'chemical-science-pack', 1},
-        {'production-science-pack', 1},
-        {'utility-science-pack', 1}
-      },
-      time = 60
-    },
-    upgrade = true,
-    order = 'sp-3'
-  },
+      prerequisites = {SP.TECHNOLOGY..'2', 'production-science-pack','utility-science-pack'},
+      unit = {
+        count = 1000,
+        ingredients = {SP.PACKS.automation, SP.PACKS.logistic, SP.PACKS.chemical, SP.PACKS.production, SP.PACKS.utility},
+        time = 60,
+      }
+    }
+  ),
   -- SP-4
-  {
-    type = 'technology',
-    name = SP.TECHNOLOGY..'4',
-    icons = util.technology_icon_constant_productivity('__base__/graphics/technology/solar-energy.png'),
-    localised_description = {'technology-description.solar-productivity', str(SP.BONUS[4] * 100)},
-    effects =
+  create_sp_technology(
+    4,
     {
-      {
-        type = 'nothing',
-        effect_description = {'effect-description.solar-productivity', str(SP.BONUS[4] * 100)}
+      prerequisites = {SP.TECHNOLOGY..'3', 'space-science-pack'},
+      unit = {
+        count_formula = '2500*(L - 3)',
+        ingredients = {SP.PACKS.automation, SP.PACKS.logistic, SP.PACKS.chemical, SP.PACKS.production, SP.PACKS.utility, SP.PACKS.space},
+        time = 60,
       },
-    },
-    prerequisites = {SP.TECHNOLOGY..'3', 'space-science-pack'},
-    unit =
-    {
-      count_formula = '2500*(L - 3)',
-      ingredients = {
-        {'automation-science-pack', 1},
-        {'logistic-science-pack', 1},
-        {'chemical-science-pack', 1},
-        {'production-science-pack', 1},
-        {'utility-science-pack', 1},
-        {'space-science-pack', 1}
-      },
-      time = 60
-    },
-    max_level = SP.LEVELS,
-    upgrade = true,
-    order = 'sp-4',
-  }
+      max_level = SP.LEVELS,
+    }
+  )
 })

--- a/scripts/upgrader.lua
+++ b/scripts/upgrader.lua
@@ -314,13 +314,15 @@ end
 Upgrader.add_commands = function()
     -- Usage: type "/sp-update" in game console
     -- Forces the game to upgrade all entities, if possible
-    commands.add_command('sp-update', { 'command-help.sp-update' }, function()
+    commands.add_command('sp-update', { 'command-help.sp-update' }, function(event)
+        if not game.players[event.player_index].admin then return end
         update_forces_levels()
         update_entities()
     end)
     -- Usage: type "/sp-transition" in game console
     -- Removes all upgraded and places back the  base prototype
-    commands.add_command('sp-transition', { 'command-help.sp-transition' }, function()
+    commands.add_command('sp-transition', { 'command-help.sp-transition' }, function(event)
+        if not game.players[event.player_index].admin then return end
         storage.transitioning = true
         storage.to_update = Queue.new() -- Clear pending upgrades
         replace_all_upgrades()

--- a/scripts/upgrader.lua
+++ b/scripts/upgrader.lua
@@ -101,24 +101,19 @@ local function transfer_properties(old, new)
     end
 end
 
---- upgrade prototype to the higher level
 ---@param old LuaEntity
-local function update_prototype(old)
-    if not (old and old.valid) then
+---@param new_name string
+--- upgrade prototypes to required level
+---@param old LuaEntity
+---@param level number
+local function change_prototype_level(old, level)
+    if not level then
         return
     end
 
-    local force = old.force
-    local level = storage.levels[force.index]
-    if not level or level == 0 then
-        return
-    end
-    -- TODO: replace all solars to "vanilla" if prod-1 is unresearched
-
-    local old_name = old.name
-    local new_name = SP.ENTITY .. level .. '-' .. sutil.base(old_name)
-
-    if old_name == new_name then
+    local base = sutil.base(old.name)
+    local new_name = level == 0 and base or SP.ENTITY .. level .. '-' .. base
+    if old.name == new_name then
         return
     end
     if not prototypes.entity[new_name] then
@@ -142,6 +137,30 @@ local function update_prototype(old)
     transfer_properties(old, new)
     old.destroy()
 end
+
+--- upgrade prototype to the higher level
+---@param old LuaEntity
+local function upgrade_prototype(old)
+    if not (old and old.valid) then
+        return
+    end
+
+    local force = old.force
+    local level = storage.levels[force.index]
+
+    -- TODO: replace all solars to "vanilla" if prod-1 is unresearched
+    change_prototype_level(old, level)
+end
+
+--- downgrade prototype to the base prototype
+---@param old LuaEntity
+local function downgrade_prototype(old)
+    if not (old and old.valid) then
+        return
+    end
+    change_prototype_level(old, 0)
+end
+
 
 -- ============================================================================
 
@@ -202,43 +221,6 @@ end
 
 -- ============================================================================
 
---- downgrade prototype to the base prototype
----@param old LuaEntity
-local function downgrade_prototype(old)
-    if not (old and old.valid) then
-        return
-    end
-
-    local old_name = old.name
-    local new_name = sutil.base(old_name)
-
-    if old_name == new_name then
-        return
-    end
-    if not prototypes.entity[new_name] then
-        return
-    end
-
-    local new = old.surface.create_entity({
-        name = new_name,
-        position = old.position,
-        force = old.force,
-        player = old.last_user,
-        quality = old.quality,
-        create_build_effect_smoke = false,
-        raise_built = true,
-    })
-
-    if not (new and new.valid) then
-        return
-    end
-
-    transfer_properties(old, new)
-    old.destroy()
-end
-
--- ============================================================================
-
 --- replaces higher tiers with the base one
 local function replace_all_upgrades()
     local to_downgrade = storage.to_downgrade
@@ -273,7 +255,7 @@ local function on_tick()
     local d_size = ceil(size(to_downgrade) / storage.interval)
 
     while u_size > 0 do
-        update_prototype(pop(to_update))
+        upgrade_prototype(pop(to_update))
         u_size = u_size - 1
     end
 


### PR DESCRIPTION
Changed technology to be generated via function instead.
Made unified change_prototype_level(old, level) function that implements functions of both update_prototype and downgrade_prototype
Generating variation prototypes now have unified function as well. 
Changed update_prototype function name to upgrade_prototype cause it makes more sense given we have downgrade_prototype (haven't changed other "update" cause im afraid it would break existing saves or whatever, idk)
Added admin check for commands as they alter the whole world, someone can just spam it, the energy on force update is not restored, etc.

Tested everything with various mods, no issues spotted.